### PR TITLE
Add Microsoft Visual C++ 2010 Redistributable to installation prerequisites

### DIFF
--- a/install.html
+++ b/install.html
@@ -84,6 +84,7 @@
 <li><strong>Visual Studio 2022 Workload: .NET Core Tools</strong> - .NET Core cross-platform development</li>
 <li><strong>.NET Framework 4.8 Developer Pack</strong> - <a href="https://www.microsoft.com/en-us/download/details.aspx?id=53321">Download</a></li>
 <li><strong>VMware Player OR Workstation</strong> VMware Player is free, so that is recommended instead - <a href="https://www.vmware.com/uk/products/workstation-player/workstation-player-evaluation.html">Download</a></li>
+<li><strong>Microsoft Visual C++ 2010 Redistributable - <a href="https://www.microsoft.com/en-us/download/details.aspx?id=26999">Download</a></li>
 </ul>
 <h3 id="installing-cosmos">Installing Cosmos</h3>
 <p>First, you need to choose between the User Kit and the Dev Kit. It is recommended that new users start with the User Kit but only move later to the Dev Kit if you need the latest features and want to contribute back to the main project.


### PR DESCRIPTION
Will hopefully prevent people having issues about yasm.exe crashing when compiling Cosmos if they don't have this